### PR TITLE
Set csv relative location

### DIFF
--- a/DnD/Form1.cs
+++ b/DnD/Form1.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using System.IO;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
+using System.Reflection;
 
 namespace DnD
 {
@@ -26,6 +27,10 @@ namespace DnD
 
         private void Form1_Load(object sender, EventArgs e)
         {
+            string workingDirectory = Path.GetDirectoryName((new System.Uri(Assembly.GetExecutingAssembly().CodeBase)).AbsolutePath);
+            string unescapedWorkingDirectory = Uri.UnescapeDataString(workingDirectory);
+            string masterFP = Path.Combine(unescapedWorkingDirectory, "CharacterStats.csv");
+            textBox1.Text = masterFP;
         }
 
         

--- a/DnD/Form1.cs
+++ b/DnD/Form1.cs
@@ -1,15 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.IO;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
 using System.Reflection;
 
 namespace DnD


### PR DESCRIPTION
This sets the default file path for CharacterStats.csv to the folder containing the running .exe
Code tested and working in Debug mode in VS 
Build tested and working on my Windows 10 Home x64 machine